### PR TITLE
Add composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,5 @@
+{
+    "name": "Hube2/acf-reusable-field-group-field",
+    "description": "ACF Reusable Field Group Field",
+    "type": "wordpress-plugin"
+}


### PR DESCRIPTION
Once merged (and with any subsequent code update), you'll want to [tag releases](https://github.com/Hube2/acf-reusable-field-group-field/releases/new) with a standard version number (e.g. `v1.0.0`)

The plugin can then be included via [Composer](https://getcomposer.org/):
```
{
    "repositories": [
        {
            "type": "composer",
            "url": "http://wpackagist.org"
        }, {
            "type": "package",
            "package": {
                "name": "advancedcustomfields/advanced-custom-fields-pro",
                "version": "5.3.8.1",
                "type": "wordpress-plugin",
                "dist": {
                    "type": "zip",
                    "url": "http://connect.advancedcustomfields.com/index.php?p=pro&a=download&k=YOUR_KEY_HERE=&t=5.3.8.1"
                },
                "require": {
                    "composer/installers": "v1.0.7"
                }
            }
        }, {
            "type": "vcs",
            "url": "git@github.com:Hube2/acf-reusable-field-group-field.git"
        }
    ],
    "require": {
        "advancedcustomfields/advanced-custom-fields-pro": "*",
        "Hube2/acf-reusable-field-group-field": "1.0.x"
    }
}
```